### PR TITLE
Update Dragon Family rules

### DIFF
--- a/dragon-family/rules.md
+++ b/dragon-family/rules.md
@@ -4,7 +4,7 @@ description: Rulebook
 categories: rules
 ---
 # SUMMARY
-Your goal is to populate the world with your brood of dragons. You will do this by exploring the world, hatching eggs, gathering your hatchling’s favorite foods to help them grow, and finally finding them a lair to call their own.
+Your goal is to raise dragons to controling large territories. You will do this by exploring the world, hatching eggs, gathering your hatchling’s favorite foods to help them grow, and finally helping them stake out a lair.
 
 # COMPONENTS
 
@@ -13,13 +13,14 @@ Your goal is to populate the world with your brood of dragons. You will do this 
 | <img src="rulebook\TileTown.png" style="max-height: 100px; clip-path: polygon(50% 4%, 94% 27%, 94% 74%, 50% 97%, 6% 74%, 6% 27%);"/> | <img src="rulebook\TileForest.png" style="max-height: 100px; clip-path: polygon(50% 4%, 94% 27%, 94% 74%, 50% 97%, 6% 74%, 6% 27%);"/> | <img src="rulebook\TileMountain.png" style="max-height: 100px; clip-path: polygon(50% 4%, 94% 27%, 94% 74%, 50% 97%, 6% 74%, 6% 27%);"/> | <img src="rulebook\TileWater.png" style="max-height: 100px; clip-path: polygon(50% 4%, 94% 27%, 94% 74%, 50% 97%, 6% 74%, 6% 27%); "/> |
 
 62 hex tiles (8 town, 17 forest, 17 mountain, 20 ocean)
+
 1 tri-hex starting tile
 
 | Egg | Green | Red | Blue | Gold |
 | --- | --- | --- | --- | --- |
 | <img src="rulebook\EggCard.png" style="max-height: 100px; background-color: rgb(199, 182, 147);"/> | <img src="rulebook\DragonGreen.png" style="max-height: 100px; background-color: rgb(199, 182, 147);"/> | <img src="rulebook\DragonRed.png" style="max-height: 100px; background-color: rgb(199, 182, 147);"/> | <img src="rulebook\DragonBlue.png" style="max-height: 100px; background-color: rgb(199, 182, 147);"/> | <img src="rulebook\DragonGold.png" style="max-height: 100px; background-color: rgb(199, 182, 147);"/> |
 
-26 egg standee cards (with dragons on the back: 6 red, 6 blue, 6 green, 6 gold)
+26 dragon standees (6 red, 6 blue, 6 green, 6 gold)
                  
 80 resources (green leaves, red rubies, blue pearls, gold)
 
@@ -31,17 +32,20 @@ Your goal is to populate the world with your brood of dragons. You will do this 
 
 # SETUP
 1. Each player takes a nest, chooses a color, and takes all handlers and lairs of that color.
-2. Place the two-sided town tile in the center of the play area.
-3. Each player places their 2 handlers on the town tile.
+2. Place the tri-hex starting tile in the center of the play area.
+3. Each player places their 2 handlers on the starting tile.
 4. Shuffle all tiles into a few face-down stacks.
 5. Deal each player 3 tiles from the stacks.
-6. Separate the dragon standees by color and place each color in a stack.
+6. Shuffle the dragon standees into a face-down pile (egg side up)
+6. Draw 3 dragons from the pile and place face-up to form a dragon market.
 7. Place all the resources in a central area to form the supply.
 8. Randomly determine a starting player. 
 
 Starting with the first player each player takes a turn in clockwise order until the game ends.
 
-# COLOR AFFINITY 
+# CORE CONCEPTS
+
+## TILES PRODUCE RESOURCES 
 Each tile has a resource that it produces:
 
 | Tile | Resource |
@@ -51,7 +55,8 @@ Each tile has a resource that it produces:
 | Ocean | Pearl (blue) |
 | Town | Gold |
 
-Each dragon has a favorite food resource (and all will accept gold):
+## DRAGONS EAT RESOURCES
+Each dragon has a preferred resource it wants to eat.
 
 | Dragon | Resource |
 | --- | --- |
@@ -59,6 +64,33 @@ Each dragon has a favorite food resource (and all will accept gold):
 | Green | Leaves / Gold |
 | Blue | Pearl / Gold |
 | Gold | Gold |
+
+All dragons will accept gold (it is a "wild" resource).
+
+## YOUR NEST
+
+Each player has a nest with room for up to 3 hatchling dragons and a supply of resources. You may spend resources to add new dragons to your nest.
+
+To **feed** a dragon you move 1 resource from your nest's supply and place it top of the dragon. You will only have the opportunity to feed your dragons once per turn.
+
+A dragon with 3 resources on it is considered fully grown and ready to create a **lair**.
+
+# TERRITORY
+
+A **territory** is a set of contiguous tiles of the same type.
+
+Ocean territories are a bit tricky and must be connected by matching water edges. If the ocean tiles touch only based on their land edge and not a water edge then they are two separate territories.
+
+At the end of the game players will earn points based on the size of the territories they **control**. Territories are controled by the player who has the most lairs in that territory. If there is a tie for most lairs then all tied players share control.
+
+It is possibile to add a lair to a territory that is already controled, however this requires paying a gold **tithe** for existing lairs. Note that if two separate territories are later joined into one by placing tiles, no tithe needs to be paid.
+
+Town tiles can never have lairs in them and thus can never be controled.
+
+## EXAMPLE
+<img src="rulebook\ScoringExample.png"/>
+
+This map has 5 potential territories. There is one forest territory with 4 tiles, one mountain in the West with 2 and another in the East with 1. There are two separate ocean territories, the North with 2 and the North East with 1 (they are separate because they don’t share a water edge). No player can ever claim the town.
  
 # YOUR TURN
 
@@ -71,39 +103,41 @@ On your turn you may do one of the following actions:
 1. Place a tile from your hand adjacent to an existing tile where you have a handler.
 - The edges of the new tile must match the edges of any existing tiles. Water edges can only touch water edges, and land edges can only touch land edges.
 2. Move that handler onto the new tile.
-3. For each adjacent tile to the placed tile gain 1 resource of the adjacent tile’s type (add to your nest).
+3. For each adjacent tile to the placed tile gain 1 resource of the adjacent tile’s type (add to your nest's supply).
 - Example: If you place a mountain tile so that it is touching an ocean tile and a forest tile you would collect 1 blue pearl (from the ocean) and 1 green leaf (from the forest)
-4. Each other player that has a handler or lair on an adjacent tile gains 1 resource of that tile’s type.
+4. For each adjacent tile where other players have pieces of their color (handler or lair), they gain 1 resource of adjacent tile's type. 
 5. Draw a tile (so that you will still have 3 in your hand).
 
 ### B) MOVE 
 <img src="rulebook\PlayerAid_Move.png" style="max-height: 100px; float: right;"/>
 
 1. Move one of your handlers from its tile to any other tile (any distance away)
-2. Gain 1 resource of that tile's type.
-Example: If you moved to a forest tile, gain 1 green leaf
-3. You may discard any tiles from your hand to the bottom of the tile stack. If you do, draw tiles until you have 3 in your hand.
+2. Gain 1 resource of that tile's type (add to your nest's supply).
+- Example: If you moved to a forest tile, gain 1 green leaf
+3. You may discard any tiles from your hand to the bottom of the tile stacks. If you do, draw tiles until you have 3 in your hand.
 
 ### C) SETTLE A LAIR
 <img src="rulebook\PlayerAid_Lair.png" style="max-height: 100px; float: right;"/>
 
-1. Choose a tile where you have a handler and there is no existing lair.
+1. Choose a non-town tile where you have a handler and there is no existing lair.
 2. Choose a dragon from your nest that has 3 food resources on it and an affinity for the chosen tile (e.g. a green dragon and a forest tile).
-  - Exception: Gold dragons may be placed on any non-town tile (no dragon can make a lair in a town).
+- Exception: Gold dragons may be placed on any non-town tile.
 
-3. Place one of your lairs on that tile, adding the dragon standee.
-  - If you have no lairs remaining the game will end at the beginning of the first player’s next turn (everyone gets an equal number of turns).
-
-After taking your action for the turn, the following happens (in this order):
+3. You must pay a tithe of 1 gold to each player for each of their lairs (if any) in the territory that contains the chosen tile. If you do not have enough gold to pay the tithe, you may not take this action.
+4. Place one of your lairs on that tile, adding the dragon standee. Return the resources on that dragon to the supply.
+ - If you have no lairs remaining the game will end at the beginning of the first player’s next turn (everyone gets an equal number of turns).
 
 ## 2) HATCH AN EGG
 <img src="rulebook\PlayerAid_Egg.png" style="max-height: 100px; float: right;"/>
 
-You may spend 3 resources of any one type (you may substitute gold for any type). If you do, take a dragon card from the egg stack that has an affinity for the resources type you spent. Add the dragon to your nest.
-- You may only have three dragons in your nest at a time
-- If you spend 3 gold resources you may choose any dragon type
+You may spend 3 resources of any one type (you may substitute gold for any type). If you do, take one of the following:
+- a face-up dragon from the market
+- a face-down dragon from the pile
+- a gold resource
 
-Alternatively, you may spend 3 resources of any one type to take a gold resource from the supply.
+If you chose a that face-up dragon from the market, replace it by flipping a dragon from the pile face-up.
+
+You may not take a dragon if it would result in you having more than 3 dragons in your nest.
 
 ## 3) FEED YOUR FAMILY
 <img src="rulebook\PlayerAid_Feed.png" style="max-height: 100px; float: right;"/>
@@ -116,19 +150,11 @@ The game end is triggered when a player creates their 4th lair or when the last 
 
 # SCORING
 When the game ends each player scores their dragons and territories:
-- Each dragon still in the nest is worth 1 point.
-- Each dragon in a lair is worth 3 points.
-- Then score 1 point for each non-lair tile that is part of your dragons’ territory. A territory is a set of contiguous tiles of the same type.
-  - Any tiles with lairs are part of the territory but are worth 0 points.
-  - If multiple players have lairs in the same territory then only the player with the most lairs in that territory scores those tiles. If there is a tie for most lairs then all those tied players score the territory.
-  - Each tile only scores for a maximum of 1 point, regardless of how many lairs a player has in that territory.
-  - Ocean territories must be connected by matching water edges. If the ocean tiles touch only based on their land edge and not a water edge then they are two separate territories.
-The player with the most points wins. If there is a tie, the tie is broken by the player with the most resources on dragons in their nest. If a tie remains it is broken by unspent resources. If a tie still remains the players share the victory.
+- Each dragon in the nest is worth 1 point.
+- Each lair is worth 3 points.
+- Each tile in territory you control is worth 1 point.
 
-## EXAMPLE
-<img src="rulebook\ScoringExample.png"/>
-
-This map has 5 potential territories. There is one forest territory with 4 tiles, one mountain in the West with 2 and another in the East with 1. There are two separate ocean territories, the North with 2 and the North East with 1 (they are separate because they don’t share a water edge). No dragons can ever claim the town.
+The player with the most points wins. If there is a tie, the tie is broken by the player with the most unspent gold resources. If a tie still remains the players share the victory.
 
 # CREDITS
 ### DESIGN, ART


### PR DESCRIPTION
- Clarify setup instructions with tri-hex
- Market of face-up dragons and face-down pile
- Move territory rules to earlier in rules
- Clarify payout for adjacent handlers/lairs
- Introduce rules to pay gold tithe to players with lairs already in the territory
- Emphasize option to trade resources for gold
- Removed rule that lair tiles do not count for points
- Tiebreaker is unspent gold
- Added core concepts to top of rules